### PR TITLE
Standardize settings page styling classes

### DIFF
--- a/home/webapp/src/components/Settings/NetworkSettingsPage.jsx
+++ b/home/webapp/src/components/Settings/NetworkSettingsPage.jsx
@@ -95,7 +95,7 @@ export default function NetworkSettingsPage() {
   };
 
   return (
-    <Styled.NetworkSettingsPageContainer>
+    <Styled.SettingsPageContainer>
       <Styled.NetworkActionBar>
         <Styled.ConnectedNetwork>
           {connectedNetwork ? 
@@ -108,6 +108,6 @@ export default function NetworkSettingsPage() {
       </Styled.NetworkActionBar>
 
       {renderWifiContent()}
-    </Styled.NetworkSettingsPageContainer>
+    </Styled.SettingsPageContainer>
   );
 }

--- a/home/webapp/src/components/SettingsPage.jsx
+++ b/home/webapp/src/components/SettingsPage.jsx
@@ -7,7 +7,7 @@ const SettingsPage = () => {
   const [activeButton, setActiveButton] = useState("WiFi");
 
   return (
-    <Styled.SettingsPageContainer>
+    <Styled.SettingsPageLayout>
       <Styled.SideMenu>
         <Styled.sideButton
           active={activeButton === "WiFi"}
@@ -42,7 +42,7 @@ const SettingsPage = () => {
       {activeButton === "WiFi" && (<NetworkSettingsPage/>)}
       {activeButton === "Profile" && (<ProfileSettingsPage/>)}
 
-    </Styled.SettingsPageContainer>
+    </Styled.SettingsPageLayout>
   );
 };
 

--- a/home/webapp/src/components/styles/Settings.styled.jsx
+++ b/home/webapp/src/components/styles/Settings.styled.jsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 
-export const SettingsPageContainer = styled.div`
-  display: flex;
+export const SettingsPageLayout = styled.div`
+  display: flex; /* Use flexbox to arrange items */
   flex-direction: row;
   gap: 13px;
   
@@ -9,7 +9,6 @@ export const SettingsPageContainer = styled.div`
   height: 100%;
   background-color: ${({ theme }) => theme.colors.background};
   border-radius: 20px;
-  font-family: 'Inter', sans-serif;
 `;
 
 export const SideMenu = styled.div`
@@ -50,22 +49,25 @@ export const sideButton = styled.div`
   }
 `;
 
-export const NetworkSettingsPageContainer = styled.div`
-  height: 340px;
-  background-color: ${({ theme }) => theme.colors.background};
+export const SettingsPageContainer = styled.div`
+  height: 100%;
+  background-color: ${({ theme }) => theme.colors.foreground};
+
+  border-radius: 20px;
 
   display: flex;
   flex-grow: 2;
   flex-direction: column;
-  justify-content: space-between;
-  gap: 10px;
-  overflow: scroll-y;
+
+  gap: 15px;
+
+  padding: 30px;
 `;
 
 export const NetworksList = styled.div`
   background-color: ${({ theme }) => theme.colors.foreground};
   border-radius: 20px;
-  height: 300px;
+  
   width: 100%;
   overflow-y: scroll;
   padding: 10px;


### PR DESCRIPTION
# Tickets Covered:
- None, quick bug fix

# Change Summary:

**1. Rename the old SettingsPageContainer to SettingsPageLayout**

Settings Page Layout sets the the Settings Sidebar and Settings Page to be side by side horizontally. 

**2. Rename NetworkSettingsPageContainer to SettingsPageContainer**

All pages use the same SettingsPageContainer div to standardize sizing, padding, and flex growth.

**3. Remove hard pixel count height on network list**
