### PR TITLE
Add code to skip key detection code if it isn't a direction

### DIFF
--- a/home/webapp/src/components/CursorProvider.jsx
+++ b/home/webapp/src/components/CursorProvider.jsx
@@ -7,6 +7,8 @@ const directions = {
   "ArrowDown": [0, 1]
 }
 
+const directionsKeys = Object.keys(directions)
+
 export default function CursorProvider({children}) {
 
   useEffect(() => {
@@ -23,6 +25,8 @@ export default function CursorProvider({children}) {
       document.activeElement.click()
       return;
     }
+
+    if (!directionsKeys.includes(key)) return;
 
     let directionVector = directions[key];
 


### PR DESCRIPTION
# Changes

**1. Fix bug where non-direction keys were raising errors**

Add code to check if the key being pressed is a directional key. Returns from function early if key is non-directional.

# Tickets Covered:
- None, quick bug fix 