### PR TITLE
Rename "for" to "htmlFor" on labels to fix React error

### DIFF
--- a/home/webapp/src/components/Settings/ProfileSettingsPage.jsx
+++ b/home/webapp/src/components/Settings/ProfileSettingsPage.jsx
@@ -79,7 +79,7 @@ function LoginPage() {
     <h1> Profile </h1>
 
     
-    <label for="email">Email:</label>
+    <label htmlFor="email">Email:</label>
     <ProfileActionInput
       type="email"
       tabIndex={0}
@@ -87,7 +87,7 @@ function LoginPage() {
       value={email}
     />
 
-    <label for="password">Password:</label>
+    <label htmlFor="password">Password:</label>
     <ProfileActionInput
       type="password"
       tabIndex={0}


### PR DESCRIPTION
# Changes

**1. Rename "for" to "htmlFor" on labels to fix React error**

React raises an error when you use the HTML attribute name 'for' in JSX code.

Friendly reminder to myself that React uses DOM API attribute names, so sometimes attributes change names between HTML and JSX code.

# Tickets Covered:
- None, quick bug fix