### PR TITLE
Eliminate overscan on Kiosk

### DIFF
--- a/home/webapp/src/components/Settings/NetworkSettingsPage.jsx
+++ b/home/webapp/src/components/Settings/NetworkSettingsPage.jsx
@@ -3,7 +3,7 @@ import * as Styled from "../styles/Settings.styled";
 
 export default function NetworkSettingsPage() {
   const [connectedNetwork, setConnectedNetwork] = useState(null);
-  const [wifiNetworks, setWifiNetworks] = useState(["Network1", "Network2", "n3", "n4", "n5", "n6", "n7", "n8"]);
+  const [wifiNetworks, setWifiNetworks] = useState([]);
 
   const fetchNetworks = async () => {
     try {

--- a/install/test-stage/00-kiosk/01-run.sh
+++ b/install/test-stage/00-kiosk/01-run.sh
@@ -15,8 +15,8 @@ echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 export DEBIAN_FRONTEND=noninteractive
 EOF
 
-install -m 644 files/config.txt "${ROOTFS_DIR}/boot/"
-install -m 644 files/cmdline.txt "${ROOTFS_DIR}/boot/"
+install -m 644 files/config.txt "${ROOTFS_DIR}/boot/firmware"
+install -m 644 files/cmdline.txt "${ROOTFS_DIR}/boot/firmware"
 
 HOME="${ROOTFS_DIR}/home/${FIRST_USER_NAME}"
 install -m 755 -o 1000 -g 1000 files/kiosk.sh "${HOME}/"

--- a/install/test-stage/00-kiosk/files/config.txt
+++ b/install/test-stage/00-kiosk/files/config.txt
@@ -7,10 +7,10 @@
 
 # uncomment the following to adjust overscan. Use positive numbers if console
 # goes off screen, and negative if there is too much border
-overscan_left=16
-overscan_right=16
-overscan_top=16
-overscan_bottom=16
+overscan_left=0
+overscan_right=0
+overscan_top=0
+overscan_bottom=0
 
 # uncomment to force a console size. By default it will be display's size minus
 # overscan.
@@ -67,11 +67,11 @@ dtoverlay=gpio-key,gpio=16,active_low=0,gpio_pull=down,keycode=30,label=GPIO_A
 dtoverlay=gpio-key,gpio=20,active_low=0,gpio_pull=down,keycode=48,label=GPIO_B
 
 # Enable DRM VC4 V3D driver
-dtoverlay=vc4-kms-v3d
-max_framebuffers=2
+#dtoverlay=vc4-kms-v3d
+#max_framebuffers=2
 
 # Disable compensation for displays with overscan
-disable_overscan=1
+#disable_overscan=1
 
 [cm4]
 # Enable host mode on the 2711 built-in XHCI USB controller.

--- a/install/test-stage/00-kiosk/files/firstrun.sh
+++ b/install/test-stage/00-kiosk/files/firstrun.sh
@@ -3,6 +3,11 @@
 echo ">> FIRST RUN"
 
 echo
+echo ">> Enabling Read-Only Overlay File System"
+sudo raspi-config nonint enable_overlayfs
+sudo raspi-config nonint enable_bootro
+
+echo
 echo ">> Unpacking Built Blastpad Package"
 tar -xf blastpad-build.tar.gz
 mv project-blastpad/start_x.sh .

--- a/install/test-stage/00-kiosk/files/kiosk.sh
+++ b/install/test-stage/00-kiosk/files/kiosk.sh
@@ -17,7 +17,7 @@ feh --bg-scale splash.png
 
 python project-blastpad/flask/serve.py & # game running does not work when started as a service
 
-chromium-browser --kiosk http://localhost:8000
+chromium-browser --kiosk http://localhost:8000 --window-position=0,0 --window-size=800,480 --force-device-scale-factor=0.999
 
 # start the cec-client & browser
 # (cec-client | cec2kbd) & browser --fullscreen "${URL:='https://deltazero.cz'}"


### PR DESCRIPTION
# Changes

**1. Added config.txt and cmdline.txt to boot/firmware**

This will move our config files into the proper location for flashing an image to the Pi.

**2. Comment out potential lines causing overscan black borders**

Removed certain lines in config.txt that had potential to add black borders.

**3. Add flags to Chromium Browser execution to change window size, position, and scale**

These turned out to the be the true cause of our overscan/black border issues in kiosk mode.

# Tickets Covered:
- [BP-249] 

[BP-249]: https://temple-cis-projects-in-cs.atlassian.net/browse/BP-249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ